### PR TITLE
Update Item_Ticket.php

### DIFF
--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -197,8 +197,7 @@ class Item_Ticket extends CommonItilObject_Item
             '_canupdate'          => false
         ];
 
-        $opt = [];
-       
+        $opt = [];    
         unset($options['entities_id']);
 
         foreach ($options as $key => $val) {

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -197,7 +197,7 @@ class Item_Ticket extends CommonItilObject_Item
             '_canupdate'          => false
         ];
 
-        $opt = [];      
+        $opt = [];
         unset($options['entities_id']);
 
         foreach ($options as $key => $val) {

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -198,6 +198,8 @@ class Item_Ticket extends CommonItilObject_Item
         ];
 
         $opt = [];
+       
+        unset($options['entities_id']);
 
         foreach ($options as $key => $val) {
             if (!empty($val)) {


### PR DESCRIPTION
Actually when we look for an item to add in a ticket, items visibility is restricted to user's active entity and its ancestors instead of the ticket ones. So when a user UI entity is the (recursive) parent of the ticket entity, items visibility is not calculated correctly and some items are missing.
